### PR TITLE
Initialize Coach Rosterbator bot scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=your_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Coach Rosterbator
+
+Early scaffold for a Discord bot that manages ice-hockey lineups and practice lobbies.
+
+## Development
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Copy `.env.example` to `.env` and set `DISCORD_TOKEN`.
+3. Run the bot:
+
+   ```bash
+   python -m rosterbator.bot
+   ```
+
+Commands are automatically scoped to the configured guild and a simple `/ping` command is available to verify the bot is online.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py>=2.5

--- a/rosterbator/bot.py
+++ b/rosterbator/bot.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Entry point for the Coach Rosterbator Discord bot."""
+
+import os
+import discord
+from discord.ext import commands
+
+from . import config
+
+
+class CoachBot(commands.Bot):
+    """Basic bot skeleton with a health check command."""
+
+    def __init__(self) -> None:
+        intents = discord.Intents.default()
+        super().__init__(command_prefix="!", intents=intents)
+
+    async def setup_hook(self) -> None:
+        guild_obj = discord.Object(id=config.GUILD_ID)
+        self.tree.copy_global_to(guild=guild_obj)
+        await self.tree.sync(guild=guild_obj)
+
+
+bot = CoachBot()
+
+
+@bot.tree.command(description="Health check")
+async def ping(interaction: discord.Interaction) -> None:
+    """Simple ping command to verify the bot is responsive."""
+
+    await interaction.response.send_message("Pong!", ephemeral=True)
+
+
+def main() -> None:
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_TOKEN not set")
+    bot.run(token)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()

--- a/rosterbator/config.py
+++ b/rosterbator/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Configuration constants for Coach Rosterbator."""
+
+from typing import Set
+
+# Guild and channel IDs
+GUILD_ID: int = 1199032891074683023
+LINEUP_CHANNEL_ID: int = 1404021808822226974
+GENERAL_CHANNEL_ID: int = 1228418184403615796
+COACH_LOG_CHANNEL_ID: int = 1199032896862822598
+
+# Manager role IDs
+MANAGER_ROLE_IDS: Set[int] = {
+    1199032891099840670,  # Owner
+    1199032891099840669,  # GM
+    1199032891099840666,  # Management
+    1404726528444731413,  # Captain
+    1228392356550807653,  # Alternate Captain
+}
+
+# Timezone for all scheduling
+TIMEZONE: str = "America/Toronto"

--- a/rosterbator/models.py
+++ b/rosterbator/models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Data models for games and practice lobbies."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List
+
+POSITIONS: List[str] = ["C", "LW", "RW", "LD", "RD", "G", "UTIL", "UTIL2"]
+
+@dataclass
+class Game:
+    """Representation of a scheduled league game."""
+
+    id: str
+    dt_iso: str
+    opponent: str
+    status: str = "upcoming"
+    roster: Dict[str, Optional[str]] = field(
+        default_factory=lambda: {pos: None for pos in POSITIONS}
+    )
+    confirmed: Dict[str, bool] = field(
+        default_factory=lambda: {pos: False for pos in POSITIONS}
+    )
+    posted_requests: Dict[str, Optional[int]] = field(
+        default_factory=lambda: {pos: None for pos in POSITIONS}
+    )
+    flags: Dict[str, object] = field(
+        default_factory=lambda: {
+            "locked": False,
+            "canceled": False,
+            "dm_6pm": False,
+            "claims_6am": False,
+            "aggressive_2h": False,
+            "util_promoted_1h": False,
+            "t30_done": False,
+            "final_call": False,
+            "last_panic_ts": 0.0,
+        }
+    )
+    lineup_message_id: Optional[int] = None
+    thread_id: Optional[int] = None
+
+
+@dataclass
+class PracticeLobby:
+    """Representation of an ad-hoc practice lobby."""
+
+    id: str
+    creator_id: int
+    channel_id: int
+    message_id: Optional[int]
+    thread_id: Optional[int]
+    opponent: str
+    start_in_min: int
+    roster: Dict[str, Optional[str]] = field(
+        default_factory=lambda: {pos: None for pos in POSITIONS[:6]}
+    )
+    flags: Dict[str, bool] = field(
+        default_factory=lambda: {
+            "announced": False,
+            "canceled": False,
+            "started": False,
+        }
+    )
+
+
+def game_from_dict(data: Dict[str, object]) -> Game:
+    """Create a :class:`Game` from a dictionary."""
+
+    return Game(**data)
+
+
+def practice_from_dict(data: Dict[str, object]) -> PracticeLobby:
+    """Create a :class:`PracticeLobby` from a dictionary."""
+
+    return PracticeLobby(**data)

--- a/rosterbator/storage.json
+++ b/rosterbator/storage.json
@@ -1,0 +1,4 @@
+{
+  "games": [],
+  "practices": []
+}

--- a/rosterbator/storage.py
+++ b/rosterbator/storage.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Persistence layer for games and practice lobbies."""
+
+import json
+import pathlib
+from typing import Dict, List
+
+STORAGE_FILE = pathlib.Path(__file__).with_name("storage.json")
+
+
+def load_storage() -> Dict[str, List]:
+    """Load storage from :data:`STORAGE_FILE`.
+
+    Returns a mapping with ``games`` and ``practices`` lists.
+    """
+
+    if STORAGE_FILE.exists():
+        with STORAGE_FILE.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+    else:
+        data = {"games": [], "practices": []}
+    return data
+
+
+def save_storage(data: Dict[str, List]) -> None:
+    """Persist *data* to :data:`STORAGE_FILE`."""
+
+    with STORAGE_FILE.open("w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- bootstrap Discord bot package with guild/channel configuration
- add dataclasses for game and practice lobby models plus JSON storage helpers
- provide entry-point bot with `/ping` slash command

## Testing
- `python -m py_compile rosterbator/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689d779be814832a831ba320d4104d9e