### PR TITLE
Add Mazda job tracker interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/job-tracker.css
+++ b/job-tracker.css
@@ -1,0 +1,133 @@
+:root {
+  --bg: #0b1b2b;
+  --card: #12263a;
+  --accent: #ff4f5e;
+  --primary: #1e90ff;
+  --text: #e9eef4;
+  --muted: #9fb3c8;
+  --success: #3ecf8e;
+  --warning: #f9c74f;
+  --danger: #f94144;
+  --low: #8ecae6;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.05), transparent 40%),
+              radial-gradient(circle at 80% 0%, rgba(255,255,255,0.05), transparent 35%),
+              var(--bg);
+  color: var(--text);
+  padding-bottom: 40px;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(11,27,43,0.9);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  padding: 14px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.brand { font-weight: 700; letter-spacing: 0.5px; }
+.pwa-hint { color: var(--muted); font-size: 0.9rem; }
+
+main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+
+.card {
+  background: var(--card);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 16px;
+  padding: 20px;
+  margin-bottom: 18px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+}
+
+.section-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.actions button { margin-left: 8px; }
+
+h1, h2, h3 { margin: 0 0 10px; }
+
+button, input, select, textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--text);
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+
+button {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+button:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(0,0,0,0.25); }
+button:active { transform: translateY(0); }
+button.accent { background: var(--accent); }
+button.primary { background: linear-gradient(90deg, #1e90ff, #7aa8ff); }
+button.secondary { background: rgba(255,255,255,0.1); }
+
+label { display: flex; flex-direction: column; gap: 6px; color: var(--muted); font-size: 0.95rem; }
+
+.filters { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-bottom: 12px; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
+
+.hidden { display: none !important; }
+
+.job-card {
+  background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+  position: relative;
+}
+.job-card.dragging { opacity: 0.6; border-style: dashed; }
+.job-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; }
+.status { padding: 6px 10px; border-radius: 20px; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.5px; }
+.status.Waiting { background: rgba(255,255,255,0.08); }
+.status.In-Progress { background: rgba(30,144,255,0.2); }
+.status.Done { background: rgba(62,207,142,0.15); color: var(--success); }
+.status.Abandoned { background: rgba(249,65,68,0.1); color: var(--danger); }
+.status.No-Show { background: rgba(249,199,79,0.15); color: var(--warning); }
+.priority { font-size: 0.85rem; padding: 4px 8px; border-radius: 10px; }
+.priority.Urgent { background: rgba(249,65,68,0.2); color: #ffdfe0; }
+.priority.Normal { background: rgba(62,207,142,0.2); color: #d6fff0; }
+.priority.Low { background: rgba(142,202,230,0.2); color: #dff4ff; }
+
+.badge { padding: 4px 8px; border-radius: 10px; background: rgba(255,255,255,0.1); font-size: 0.85rem; }
+
+.form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 10px; }
+.task-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 8px; margin: 12px 0; }
+textarea { resize: vertical; min-height: 80px; }
+.form-actions { display: flex; gap: 8px; }
+
+.calendar { margin-top: 10px; }
+.calendar-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.calendar-column { border: 1px dashed rgba(255,255,255,0.1); border-radius: 12px; padding: 10px; background: rgba(255,255,255,0.02); min-height: 140px; }
+.calendar-column h4 { margin: 0 0 8px; display: flex; justify-content: space-between; align-items: center; }
+
+.welcome-actions { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
+
+.qr-area { display: flex; gap: 10px; align-items: center; }
+.qr-area img { width: 96px; height: 96px; border-radius: 8px; border: 1px solid rgba(255,255,255,0.1); object-fit: cover; background: #fff; }
+
+.warning { color: var(--warning); margin: 6px 0 0; }
+.error { color: var(--danger); }
+
+@media (max-width: 700px) {
+  main { padding: 12px; }
+  .section-header, .app-header { flex-direction: column; align-items: flex-start; }
+  button, input, select { font-size: 1rem; }
+}

--- a/job-tracker.html
+++ b/job-tracker.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mazda Gaspé Job Tracker</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="job-tracker.css">
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">Mazda Gaspé Job Tracker</div>
+    <div class="pwa-hint">Installable • Offline-ready</div>
+  </header>
+
+  <main>
+    <section id="welcome-screen" class="card">
+      <h1>Welcome</h1>
+      <p>Select your workspace</p>
+      <div class="welcome-actions">
+        <button id="go-garage" class="primary">🚗 Garage View (Technicians)</button>
+        <button id="go-service" class="accent">🛠 Service Department (Managers)</button>
+      </div>
+    </section>
+
+    <section id="technician-view" class="card hidden">
+      <header class="section-header">
+        <h2>Technician Schedule</h2>
+        <div class="qr-area">
+          <label for="qr-technician">QR for technician page</label>
+          <select id="qr-technician"></select>
+          <img id="qr-preview" alt="QR code" />
+        </div>
+      </header>
+      <div class="filters">
+        <label>Technician
+          <select id="tech-filter"></select>
+        </label>
+        <label>Date
+          <input type="date" id="date-filter">
+        </label>
+        <label>Status
+          <select id="tech-status-filter">
+            <option value="">All</option>
+            <option>Waiting</option>
+            <option>In Progress</option>
+            <option>Done</option>
+            <option>Abandoned</option>
+            <option>No-Show</option>
+          </select>
+        </label>
+      </div>
+      <div id="tech-cards" class="card-grid"></div>
+    </section>
+
+    <section id="manager-login" class="card hidden">
+      <h2>Manager Login</h2>
+      <label>Password
+        <input type="password" id="manager-password" placeholder="mazda123">
+      </label>
+      <button id="login-btn" class="primary">Unlock Dashboard</button>
+      <p id="login-error" class="error"></p>
+    </section>
+
+    <section id="manager-dashboard" class="card hidden">
+      <header class="section-header">
+        <h2>Service Department Dashboard</h2>
+        <div class="actions">
+          <button id="export-csv">📤 Export CSV</button>
+          <button id="export-pdf">🖨️ Export PDF</button>
+          <button id="pwa-install" class="accent">⬇️ Install App</button>
+        </div>
+      </header>
+      <div class="filters">
+        <label>Technician
+          <select id="manager-tech-filter"></select>
+        </label>
+        <label>Status
+          <select id="manager-status-filter">
+            <option value="">All</option>
+            <option>Waiting</option>
+            <option>In Progress</option>
+            <option>Done</option>
+            <option>Abandoned</option>
+            <option>No-Show</option>
+          </select>
+        </label>
+        <label>Priority
+          <select id="priority-filter">
+            <option value="">All</option>
+            <option>Urgent</option>
+            <option>Normal</option>
+            <option>Low</option>
+          </select>
+        </label>
+        <label>Date
+          <input type="date" id="manager-date-filter">
+        </label>
+      </div>
+
+      <div class="dashboard">
+        <form id="job-form" class="card">
+          <div class="form-grid">
+            <label>Client name<input id="client" required></label>
+            <label>Vehicle<input id="vehicle" placeholder="Make / Model"></label>
+            <label>Stock #<input id="stock"></label>
+            <label>Technician<select id="technician"></select></label>
+            <label>Date<input type="date" id="date" required></label>
+            <label>Time<input type="time" id="time" required></label>
+            <label>Duration (hrs)<input type="number" id="duration" min="0.25" step="0.25" value="1"></label>
+            <label>Status<select id="status">
+              <option>Waiting</option>
+              <option>In Progress</option>
+              <option>Done</option>
+              <option>Abandoned</option>
+              <option>No-Show</option>
+            </select></label>
+            <label>Priority<select id="priority">
+              <option>Urgent</option>
+              <option selected>Normal</option>
+              <option>Low</option>
+            </select></label>
+            <label>Job template<select id="template"></select></label>
+          </div>
+
+          <div id="task-selectors" class="task-grid"></div>
+          <label>Notes<textarea id="notes" rows="3"></textarea></label>
+
+          <div class="form-actions">
+            <button type="submit" class="primary" id="save-job">Save job</button>
+            <button type="button" id="reset-form">Clear</button>
+          </div>
+          <p id="overlap-warning" class="warning"></p>
+        </form>
+
+        <div class="calendar">
+          <div class="calendar-header">
+            <h3>Calendar (drag to reschedule)</h3>
+            <div id="hours-summary"></div>
+          </div>
+          <div id="calendar-grid" class="calendar-grid"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="job-tracker.js"></script>
+</body>
+</html>

--- a/job-tracker.js
+++ b/job-tracker.js
@@ -1,0 +1,440 @@
+const TECHNICIANS = ["Jean David", "Mr. Cotton", "Eric", "Emmy"];
+const TEMPLATES = {
+  "Service #1": ["Oil change", "Brake inspection", "Tire rotation"],
+  "Service #2": ["Transmission check", "Coolant flush", "Electrical scan"],
+  "Hybrid": ["Battery health", "Inverter test", "Cooling loop inspection"],
+  "Oil": ["Oil change", "Filter swap", "Top-up fluids"],
+  "Brake Clean": ["Caliper clean", "Rotor resurface", "Pad measurement"],
+};
+
+const defaultJobs = [
+  {
+    id: crypto.randomUUID(),
+    client: "Marie D.",
+    vehicle: "CX-5 Touring",
+    stock: "MX-204",
+    technician: "Jean David",
+    date: today(),
+    time: "09:00",
+    duration: 1.5,
+    tasks: ["Oil change", "Brake inspection"],
+    notes: "Customer waiting room",
+    status: "Waiting",
+    priority: "Urgent",
+    template: "Service #1",
+    noShow: false,
+  },
+  {
+    id: crypto.randomUUID(),
+    client: "Studio Boreal",
+    vehicle: "Mazda3 GS",
+    stock: "MX-198",
+    technician: "Emmy",
+    date: today(1),
+    time: "13:00",
+    duration: 2,
+    tasks: ["Battery health", "Inverter test"],
+    notes: "Hybrid diagnostics",
+    status: "In Progress",
+    priority: "Normal",
+    template: "Hybrid",
+    noShow: false,
+  },
+];
+
+let jobs = loadJobs();
+let editingId = null;
+let deferredPrompt = null;
+
+function today(add = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + add);
+  return d.toISOString().slice(0, 10);
+}
+
+function loadJobs() {
+  const saved = localStorage.getItem("mazda-jobs");
+  if (saved) {
+    try {
+      return JSON.parse(saved);
+    } catch (e) {
+      console.warn("Could not parse jobs", e);
+    }
+  }
+  return defaultJobs;
+}
+
+function saveJobs() {
+  localStorage.setItem("mazda-jobs", JSON.stringify(jobs));
+}
+
+function byId(id) { return document.getElementById(id); }
+
+function init() {
+  populateTechnicians();
+  populateTemplates();
+  renderQR();
+  renderTechCards();
+  renderDashboard();
+  attachEvents();
+  renderTasks();
+  setForm();
+  resolveLandingView();
+  registerServiceWorker();
+}
+
+document.addEventListener("DOMContentLoaded", init);
+
+function populateTechnicians() {
+  const techSelects = ["tech-filter", "technician", "manager-tech-filter", "qr-technician"]
+    .map(byId);
+  techSelects.forEach(sel => {
+    if (!sel) return;
+    sel.innerHTML = TECHNICIANS.map(t => `<option value="${t}">${t}</option>`).join("");
+    const defaultTech = new URLSearchParams(location.search).get("tech");
+    if (defaultTech && TECHNICIANS.includes(defaultTech)) {
+      sel.value = defaultTech;
+    }
+  });
+}
+
+function populateTemplates() {
+  const templateSelect = byId("template");
+  templateSelect.innerHTML = Object.keys(TEMPLATES).map(t => `<option>${t}</option>`).join("");
+  templateSelect.addEventListener("change", () => applyTemplate(templateSelect.value));
+  applyTemplate(templateSelect.value);
+}
+
+function renderTasks(tasks = []) {
+  const container = byId("task-selectors");
+  container.innerHTML = "";
+  for (let i = 0; i < 6; i++) {
+    const selector = document.createElement("select");
+    selector.innerHTML = `<option value="">Task #${i + 1}</option>` +
+      Array.from(new Set(Object.values(TEMPLATES).flat())).map(t => `<option>${t}</option>`).join("");
+    selector.value = tasks[i] || "";
+    container.appendChild(selector);
+  }
+}
+
+function applyTemplate(template) {
+  const tasks = TEMPLATES[template] || [];
+  renderTasks(tasks);
+}
+
+function attachEvents() {
+  byId("go-garage").onclick = () => showSection("technician-view");
+  byId("go-service").onclick = () => showSection("manager-login");
+  byId("login-btn").onclick = login;
+  byId("job-form").addEventListener("submit", saveJob);
+  byId("reset-form").onclick = () => setForm();
+  byId("tech-filter").onchange = renderTechCards;
+  byId("tech-status-filter").onchange = renderTechCards;
+  byId("date-filter").onchange = renderTechCards;
+  ["manager-tech-filter", "manager-status-filter", "priority-filter", "manager-date-filter"].forEach(id => {
+    byId(id).onchange = renderDashboard;
+  });
+  byId("export-csv").onclick = exportCSV;
+  byId("export-pdf").onclick = exportPDF;
+  byId("pwa-install").onclick = installPrompt;
+  byId("qr-technician").onchange = renderQR;
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+  });
+}
+
+function showSection(id) {
+  ["welcome-screen", "technician-view", "manager-login", "manager-dashboard"].forEach(sec => {
+    byId(sec).classList.toggle("hidden", sec !== id);
+  });
+}
+
+function login() {
+  const pass = byId("manager-password").value.trim();
+  if (pass === "mazda123") {
+    byId("login-error").textContent = "";
+    showSection("manager-dashboard");
+  } else {
+    byId("login-error").textContent = "Incorrect password";
+  }
+}
+
+function gatherForm() {
+  const taskSelectors = Array.from(byId("task-selectors").querySelectorAll("select"));
+  const tasks = taskSelectors.map(s => s.value).filter(Boolean);
+  return {
+    id: editingId || crypto.randomUUID(),
+    client: byId("client").value,
+    vehicle: byId("vehicle").value,
+    stock: byId("stock").value,
+    technician: byId("technician").value,
+    date: byId("date").value,
+    time: byId("time").value,
+    duration: parseFloat(byId("duration").value || 0),
+    tasks,
+    notes: byId("notes").value,
+    status: byId("status").value,
+    priority: byId("priority").value,
+    template: byId("template").value,
+    noShow: byId("status").value === "No-Show",
+  };
+}
+
+function setForm(job = null) {
+  editingId = job?.id || null;
+  byId("save-job").textContent = job ? "Update job" : "Save job";
+  byId("client").value = job?.client || "";
+  byId("vehicle").value = job?.vehicle || "";
+  byId("stock").value = job?.stock || "";
+  byId("technician").value = job?.technician || TECHNICIANS[0];
+  byId("date").value = job?.date || today();
+  byId("time").value = job?.time || "08:00";
+  byId("duration").value = job?.duration || 1;
+  byId("status").value = job?.status || "Waiting";
+  byId("priority").value = job?.priority || "Normal";
+  byId("template").value = job?.template || Object.keys(TEMPLATES)[0];
+  renderTasks(job?.tasks || []);
+  byId("notes").value = job?.notes || "";
+  byId("overlap-warning").textContent = "";
+}
+
+function saveJob(e) {
+  e.preventDefault();
+  const job = gatherForm();
+  if (!job.client || !job.date || !job.time) return;
+
+  const overlap = detectOverlap(job, editingId);
+  byId("overlap-warning").textContent = overlap ? `⚠️ Overlap with ${overlap.client} at ${overlap.time}` : "";
+
+  if (editingId) {
+    jobs = jobs.map(j => j.id === editingId ? job : j);
+  } else {
+    jobs.push(job);
+  }
+  saveJobs();
+  renderTechCards();
+  renderDashboard();
+  setForm();
+}
+
+function detectOverlap(job, ignoreId = null) {
+  const start = new Date(`${job.date}T${job.time}`);
+  const end = new Date(start.getTime() + job.duration * 60 * 60 * 1000);
+  return jobs.find(j => {
+    if (j.id === ignoreId) return false;
+    if (j.technician !== job.technician || j.date !== job.date) return false;
+    const jStart = new Date(`${j.date}T${j.time}`);
+    const jEnd = new Date(jStart.getTime() + j.duration * 60 * 60 * 1000);
+    return jStart < end && start < jEnd;
+  });
+}
+
+function renderTechCards() {
+  const tech = byId("tech-filter").value || TECHNICIANS[0];
+  const date = byId("date-filter").value || today();
+  const status = byId("tech-status-filter").value;
+  const container = byId("tech-cards");
+  container.innerHTML = "";
+  const filtered = jobs
+    .filter(j => j.technician === tech && j.date === date)
+    .filter(j => !status || j.status === status)
+    .sort((a,b) => a.time.localeCompare(b.time));
+
+  filtered.forEach(job => container.appendChild(jobCard(job, false)));
+}
+
+function jobCard(job, editable) {
+  const card = document.createElement("div");
+  card.className = "job-card";
+  card.draggable = editable;
+  card.dataset.id = job.id;
+
+  const statusClass = job.status.replace(/\s+/g, "-");
+  card.innerHTML = `
+    <div class="job-header">
+      <div>
+        <strong>${job.client}</strong>
+        <div class="badge">${job.vehicle}${job.stock ? ` • ${job.stock}` : ""}</div>
+      </div>
+      <div class="status ${statusClass}">${job.status}</div>
+    </div>
+    <div class="badge">${job.date} • ${job.time} • ${job.duration}h</div>
+    <div class="badge">Tasks: ${job.tasks.join(", ") || "—"}</div>
+    <div class="badge">Notes: ${job.notes || "—"}</div>
+    <div class="badge priority ${job.priority}">${job.priority}</div>
+  `;
+
+  if (editable) {
+    card.addEventListener("dragstart", dragStart);
+    card.addEventListener("dragend", dragEnd);
+    const actions = document.createElement("div");
+    actions.className = "form-actions";
+    const editBtn = document.createElement("button");
+    editBtn.textContent = "Edit";
+    editBtn.onclick = () => setForm(job);
+    const delBtn = document.createElement("button");
+    delBtn.textContent = "Delete";
+    delBtn.className = "accent";
+    delBtn.onclick = () => deleteJob(job.id);
+    actions.append(editBtn, delBtn);
+    card.appendChild(actions);
+  }
+
+  return card;
+}
+
+function deleteJob(id) {
+  if (!confirm("Delete this job?")) return;
+  jobs = jobs.filter(j => j.id !== id);
+  saveJobs();
+  renderTechCards();
+  renderDashboard();
+}
+
+function renderDashboard() {
+  const filters = {
+    tech: byId("manager-tech-filter").value,
+    status: byId("manager-status-filter").value,
+    priority: byId("priority-filter").value,
+    date: byId("manager-date-filter").value,
+  };
+
+  const filtered = jobs.filter(j => (
+    (!filters.tech || j.technician === filters.tech) &&
+    (!filters.status || j.status === filters.status) &&
+    (!filters.priority || j.priority === filters.priority) &&
+    (!filters.date || j.date === filters.date)
+  ));
+
+  const grid = byId("calendar-grid");
+  grid.innerHTML = "";
+
+  const grouped = groupByDate(filtered);
+  Object.entries(grouped).forEach(([date, list]) => {
+    const col = document.createElement("div");
+    col.className = "calendar-column";
+    col.dataset.date = date;
+    col.addEventListener("dragover", dragOver);
+    col.addEventListener("drop", (e) => dropOnDate(e, date));
+
+    const hours = list.reduce((sum, j) => sum + j.duration, 0);
+    col.innerHTML = `<h4>${date} <span class="badge">${hours.toFixed(1)}h</span></h4>`;
+    list.sort((a,b) => a.time.localeCompare(b.time)).forEach(job => {
+      const card = jobCard(job, true);
+      col.appendChild(card);
+    });
+    grid.appendChild(col);
+  });
+
+  renderHoursSummary();
+}
+
+function groupByDate(list) {
+  return list.reduce((acc, job) => {
+    acc[job.date] = acc[job.date] || [];
+    acc[job.date].push(job);
+    return acc;
+  }, {});
+}
+
+function dragStart(e) {
+  e.dataTransfer.setData("text/plain", e.target.dataset.id);
+  e.currentTarget.classList.add("dragging");
+}
+
+function dragEnd(e) {
+  e.currentTarget.classList.remove("dragging");
+}
+
+function dragOver(e) {
+  e.preventDefault();
+}
+
+function dropOnDate(e, date) {
+  e.preventDefault();
+  const id = e.dataTransfer.getData("text/plain");
+  const job = jobs.find(j => j.id === id);
+  if (!job) return;
+  const newTime = prompt("New start time (HH:MM)?", job.time) || job.time;
+  const updated = { ...job, date, time: newTime };
+  const overlap = detectOverlap(updated, id);
+  if (overlap) {
+    alert(`Overlap detected with ${overlap.client}`);
+    return;
+  }
+  jobs = jobs.map(j => j.id === id ? updated : j);
+  saveJobs();
+  renderTechCards();
+  renderDashboard();
+}
+
+function renderHoursSummary() {
+  const summary = {};
+  jobs.forEach(job => {
+    const key = `${job.date}|${job.technician}`;
+    summary[key] = (summary[key] || 0) + job.duration;
+  });
+  const container = byId("hours-summary");
+  container.innerHTML = Object.entries(summary)
+    .map(([key, hours]) => {
+      const [date, tech] = key.split("|");
+      return `<span class="badge">${date} • ${tech}: ${hours.toFixed(1)}h</span>`;
+    }).join(" ");
+}
+
+function exportCSV() {
+  const header = ["Client","Vehicle","Stock","Technician","Date","Time","Duration","Tasks","Notes","Status","Priority"];
+  const rows = jobs.map(j => [j.client,j.vehicle,j.stock,j.technician,j.date,j.time,j.duration,j.tasks.join(" | "),j.notes,j.status,j.priority]);
+  const csv = [header, ...rows].map(r => r.map(v => `"${(v ?? "").toString().replace(/"/g,'""')}"`).join(",")).join("\n");
+  downloadFile(csv, "jobs.csv", "text/csv");
+}
+
+function exportPDF() {
+  const html = jobs.map(j => `<tr><td>${j.client}</td><td>${j.vehicle}</td><td>${j.technician}</td><td>${j.date}</td><td>${j.time}</td><td>${j.status}</td></tr>`).join("");
+  const doc = window.open("", "print");
+  doc.document.write(`<style>table{width:100%;border-collapse:collapse;font-family:sans-serif}td,th{border:1px solid #999;padding:6px;text-align:left}</style><table><tr><th>Client</th><th>Vehicle</th><th>Tech</th><th>Date</th><th>Time</th><th>Status</th></tr>${html}</table>`);
+  doc.document.close();
+  doc.print();
+}
+
+function downloadFile(content, filename, type) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = filename; a.click();
+  URL.revokeObjectURL(url);
+}
+
+function renderQR() {
+  const tech = byId("qr-technician").value || TECHNICIANS[0];
+  const url = `${location.origin}${location.pathname}?tech=${encodeURIComponent(tech)}`;
+  const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=${encodeURIComponent(url)}`;
+  byId("qr-preview").src = qrUrl;
+}
+
+function resolveLandingView() {
+  const params = new URLSearchParams(location.search);
+  const tech = params.get("tech");
+  const view = params.get("view");
+  if (tech && TECHNICIANS.includes(tech)) {
+    byId("tech-filter").value = tech;
+    showSection("technician-view");
+  } else if (view === "manager") {
+    showSection("manager-login");
+  } else {
+    showSection("welcome-screen");
+  }
+}
+
+function registerServiceWorker() {
+  if (!('serviceWorker' in navigator)) return;
+  navigator.serviceWorker.register('service-worker.js').catch(console.error);
+}
+
+function installPrompt() {
+  if (deferredPrompt) {
+    deferredPrompt.prompt();
+  }
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Mazda Gaspé Job Tracker",
+  "short_name": "Job Tracker",
+  "start_url": "job-tracker.html",
+  "display": "standalone",
+  "background_color": "#0b1b2b",
+  "theme_color": "#1e90ff",
+  "icons": [
+    {
+      "src": "https://api.qrserver.com/v1/create-qr-code/?size=192x192&data=Mazda",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'mazda-job-tracker-v1';
+const ASSETS = [
+  'job-tracker.html',
+  'job-tracker.css',
+  'job-tracker.js',
+  'manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add Mazda Gaspé Job Tracker single-page experience with welcome, technician view, and manager dashboard
- implement job CRUD with templates, filters, overlap detection, CSV/PDF export, QR codes, and drag-and-drop rescheduling
- add PWA assets (manifest and service worker) plus localStorage persistence for offline use

## Testing
- node -c job-tracker.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692431c6da6c832a8b89528263b94ab3)